### PR TITLE
fix: jose_plus and crypto_keys_plus packages upgraded

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,8 @@
 name: selective_disclosure_jwt
-version: 1.0.1
-description: A Dart SDK for working with Selective Disclosure JSON Web Tokens (SD-JWT) following the SD-JWT specification.
+version: 1.0.2
+description: >-
+  A Dart SDK for working with Selective Disclosure JSON Web Tokens
+  (SD-JWT) following the SD-JWT specification.
 repository: https://github.com/affinidi/affinidi-sdjwt-dart
 issue_tracker: https://github.com/affinidi/affinidi-sdjwt-dart/issues
 
@@ -17,19 +19,19 @@ environment:
 dependencies:
   convert: ^3.1.2
   crypto: ^3.0.6
-  jose_plus: ^0.4.6
-  uuid: ^4.5.1
+  crypto_keys_plus: ^0.5.0
   equatable: ^2.0.7
-  crypto_keys_plus: ^0.4.0
-  rfc_6901: ^0.2.0
+  jose_plus: ^0.4.7
   meta: ^1.15.0
+  rfc_6901: ^0.2.0
+  uuid: ^4.5.1
 
 dev_dependencies:
-  path: ^1.9.1
   lints: ^5.1.1
-  test: ^1.25.15
-  mocktail: ^1.0.4
   melos: ^6.3.2
+  mocktail: ^1.0.4
+  path: ^1.9.1
+  test: ^1.25.15
 
 false_secrets:
   - test/resources/*.pem


### PR DESCRIPTION
- `jose_plus` updated to `^0.4.7`
- `crypto_keys_plus` updated to `^0.5.0`
- All packages now support `pointycastle: ^4.0.0`